### PR TITLE
Fix exception with composer-installer v5

### DIFF
--- a/Resources/Private/Templates/Index/Index.html
+++ b/Resources/Private/Templates/Index/Index.html
@@ -2,7 +2,7 @@
       data-namespace-typo3-fluid="true">
 
 <div class="image">
-    <f:image src="EXT:content_information/Resources/Public/Icons/Claim.png" width="400"></f:image>
+    <img src="{f:uri.resource(path: 'EXT:content_information/Resources/Public/Icons/Claim.png')}" width="400" />
 </div>
 
 <div class="row">


### PR DESCRIPTION
Replace `<f:image src="` ViewHelper with `<img src="{f:uri.resource(` to avoid file not found exception.